### PR TITLE
Update index.md

### DIFF
--- a/task-reference/index.md
+++ b/task-reference/index.md
@@ -302,7 +302,7 @@ For how-tos and tutorials about authoring pipelines using tasks, including creat
 | **IIS web app manage**<br>[IISWebAppManagementOnMachineGroup@0](iisweb-app-management-on-machine-group-v0.md) | Create or update websites, web apps, virtual directories, or application pools. |
 | **Invoke REST API**<br>[InvokeRESTAPI@1](invoke-rest-api-v1.md)<br>[InvokeRESTAPI@0](invoke-rest-api-v0.md) | Invoke a REST API as a part of your pipeline. |
 | **Kubectl**<br>[Kubernetes@1](kubernetes-v1.md)<br>[Kubernetes@0](kubernetes-v0.md) | Deploy, configure, update a Kubernetes cluster in Azure Container Service by running kubectl commands. |
-| **Manual intervention**<br>[ManualIntervention@8](manual-intervention-v8.md) | Pause deployment and wait for manual intervention. |
+| **Manual intervention**<br>[ManualIntervention@8](manual-intervention-v8.md) | Pause deployment and wait for manual intervention. Works only with classic release pipelines. |
 | **Manual validation**<br>[ManualValidation@0](manual-validation-v0.md) | [PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines. |
 | **MySQL database deploy**<br>[MysqlDeploymentOnMachineGroup@1](mysql-deployment-on-machine-group-v1.md) | Run scripts and make changes to a MySQL Database. |
 | **Package and deploy Helm charts**<br>[HelmDeploy@0](helm-deploy-v0.md) | Deploy, configure, update a Kubernetes cluster in Azure Container Service by running helm commands. |


### PR DESCRIPTION
ManualInvention has been updated to specify it can only be used in classic release pipeline. Updating the index as well to make that clear.